### PR TITLE
Added remove query string flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Install with [npm](https://www.npmjs.com/):
 
     Options:
       --output, -o Output directory
+      --remove-query-string, -r Remove query string from file path
       --dry-run Enable dry run mode
       --verbose Show processing file path
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -11,6 +11,7 @@ const cli = meow(
 
     Options:
       --output, -o Output directory
+      --remove-query-string, -r Remove query string from file path
       --dry-run Enable dry run mode
       --verbose Show processing file path
 
@@ -22,6 +23,11 @@ const cli = meow(
             output: {
                 type: "string",
                 alias: "o"
+            },
+            removeQueryString: {
+                type: "boolean",
+                alias: "r",
+                default: false
             },
             verbose: {
                 type: "boolean",
@@ -45,6 +51,7 @@ try {
     extract(harContent, {
         verbose: cli.flags.verbose,
         dryRun: cli.flags.dryRun,
+        removeQueryString: cli.flags.removeQueryString,
         outputDir: cli.flags.output
     });
 } catch (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "har-extractor",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A CLI that extract har file to directory.",
   "keywords": [
     "archieve",

--- a/src/har-extractor.ts
+++ b/src/har-extractor.ts
@@ -18,9 +18,9 @@ export const getEntryContentAsBuffer = (entry: Entry): Buffer | undefined => {
     }
 };
 
-export const convertEntryAsFilePathFormat = (entry: Entry): string => {
+export const convertEntryAsFilePathFormat = (entry: Entry, removeQueryString: boolean = false): string => {
     const requestURL = entry.request.url;
-    const stripSchemaURL: string = humanizeUrl(requestURL);
+    const stripSchemaURL: string = humanizeUrl(removeQueryString ? requestURL.split("?")[0] : requestURL);
     const dirnames: string[] = stripSchemaURL.split("/").map(pathname => {
         return filenamify(pathname);
     });
@@ -35,6 +35,7 @@ export interface ExtractOptions {
     outputDir: string;
     verbose?: boolean;
     dryRun?: boolean;
+    removeQueryString?: boolean;
 }
 
 export const extract = (harContent: Har, options: ExtractOptions) => {
@@ -43,7 +44,7 @@ export const extract = (harContent: Har, options: ExtractOptions) => {
         if (!buffer) {
             return;
         }
-        const outputPath = path.join(options.outputDir, convertEntryAsFilePathFormat(entry));
+        const outputPath = path.join(options.outputDir, convertEntryAsFilePathFormat(entry, options.removeQueryString));
         if (!options.dryRun) {
             makeDir.sync(path.dirname(outputPath));
         }


### PR DESCRIPTION
This PR adds `--remove-query-string` (and `-r` as alias) flag to remove query strings from file paths. This is helpful for removing versioning info  for instance. I.e. for `app.js?v=42` we will get `app.js` not `app.js!v=42`.