### PR TITLE
Fix HAR extraction for conflicting URL paths

### DIFF
--- a/src/har-extractor.ts
+++ b/src/har-extractor.ts
@@ -22,7 +22,7 @@ export const convertEntryAsFilePathFormat = (entry: Entry, removeQueryString: bo
     const requestURL = entry.request.url;
     const stripSchemaURL: string = humanizeUrl(removeQueryString ? requestURL.split("?")[0] : requestURL);
     const dirnames: string[] = stripSchemaURL.split("/").map((pathname) => {
-        return filenamify(pathname, {maxLength: 255});
+        return filenamify(pathname, { maxLength: 255 });
     });
     const fileName = dirnames[dirnames.length - 1];
     if (
@@ -58,7 +58,7 @@ const ensureDir = (dirPath: string): void => {
                 const fileContent = fs.readFileSync(subPath); // Read the file content
                 fs.unlinkSync(subPath); // Remove the file
                 fs.mkdirSync(subPath); // Create the directory
-                fs.writeFileSync(path.join(subPath, 'index'), fileContent); // Write the file content to index
+                fs.writeFileSync(path.join(subPath, "index"), fileContent); // Write the file content to index
             }
         } else {
             // If subPath does not exist, create the directory
@@ -79,8 +79,8 @@ export const extract = (harContent: Har, options: ExtractOptions) => {
         if (!options.dryRun && outputDir.length > 0) {
             try {
                 ensureDir(outputDir);
-            } catch (error) {
-                if (error.code !== 'EEXIST') {
+            } catch (error: any) {
+                if (error?.code !== "EEXIST") {
                     throw error;
                 }
             }

--- a/src/har-extractor.ts
+++ b/src/har-extractor.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 
 const filenamify = require("filenamify");
 const humanizeUrl = require("humanize-url");
-const makeDir = require("make-dir");
+
 export const getEntryContentAsBuffer = (entry: Entry): Buffer | undefined => {
     const content = entry.response.content;
     const text = content.text;
@@ -43,6 +43,30 @@ export interface ExtractOptions {
     removeQueryString?: boolean;
 }
 
+const ensureDir = (dirPath: string): void => {
+    // Split the path into components
+    const parts = dirPath.split(path.sep);
+    console.log(parts);
+
+    // Iterate through each part of the path
+    for (let i = 1; i <= parts.length; i++) {
+        const subPath = parts.slice(0, i).join(path.sep);
+
+        if (fs.existsSync(subPath)) {
+            if (fs.lstatSync(subPath).isFile()) {
+                // If subPath is a file, move it to an index file within a new directory
+                const fileContent = fs.readFileSync(subPath); // Read the file content
+                fs.unlinkSync(subPath); // Remove the file
+                fs.mkdirSync(subPath); // Create the directory
+                fs.writeFileSync(path.join(subPath, 'index'), fileContent); // Write the file content to index
+            }
+        } else {
+            // If subPath does not exist, create the directory
+            fs.mkdirSync(subPath);
+        }
+    }
+};
+
 export const extract = (harContent: Har, options: ExtractOptions) => {
     harContent.log.entries.forEach((entry) => {
         const buffer = getEntryContentAsBuffer(entry);
@@ -50,9 +74,18 @@ export const extract = (harContent: Har, options: ExtractOptions) => {
             return;
         }
         const outputPath = path.join(options.outputDir, convertEntryAsFilePathFormat(entry, options.removeQueryString));
-        if (!options.dryRun) {
-            makeDir.sync(path.dirname(outputPath));
+        const outputDir = path.dirname(outputPath);
+
+        if (!options.dryRun && outputDir.length > 0) {
+            try {
+                ensureDir(outputDir);
+            } catch (error) {
+                if (error.code !== 'EEXIST') {
+                    throw error;
+                }
+            }
         }
+
         if (options.verbose) {
             console.log(outputPath);
         }


### PR DESCRIPTION
This PR addresses an issue where HAR entries with conflicting prefixes could not be properly represented in the filesystem. The changes implement a more robust directory creation process that can handle cases where a file and a directory might need to exist at the same path.


Changes

- Implemented ensureDir function to manage directory creation
- Replaced makeDir.sync with custom ensureDir logic
- Added handling for cases where file and directory names conflict
- Improved error handling for directory creation process
- Removed unused makeDir import

Implementation Details
The new ensureDir function walks through each part of a path, creating directories as needed. If it encounters a file where a directory should be, it moves the file to an `index` file within a new directory at that location. This allows us to represent both server.com/foo (as server.com/foo/index) and server.com/foo/bar (as server.com/foo/bar) in the filesystem.
