### PR TITLE
entry.response.content.text can be empty

### DIFF
--- a/src/har-extractor.ts
+++ b/src/har-extractor.ts
@@ -8,7 +8,7 @@ const makeDir = require("make-dir");
 export const getEntryContentAsBuffer = (entry: Entry): Buffer | undefined => {
     const content = entry.response.content;
     const text = content.text;
-    if (text === undefined) {
+    if (text === undefined || text === '') {
         return;
     }
     if (content.encoding === "base64") {


### PR DESCRIPTION
entry.response.content.text in getEntryContentAsBuffer can be empty (''), so it shouldn't be extracted as it overwrites files with content. Fixes #10

At the moment the iteration also includes files with size > 0 but no content. With this simple fix no zero-bytes files overwrite the already extracted files with content.