### PR TITLE
chore: update Node.js maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18, 20, 22 ]
+        node-version: [ 20, 22, 24 ]
     steps:
       - name: checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         node-version: [ 20, 22, 24 ]
     steps:
       - name: checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         node-version: [ 18, 20, 22 ]
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install


### PR DESCRIPTION
## Summary
- Updated GitHub Actions to use latest versions
- Updated Node.js versions in CI matrix (20, 22, 24)
- Pinned GitHub Actions versions for security

## Changes
- Updated `actions/checkout` from v2.7.0 to v5.0.0
- Updated `actions/setup-node` from v1.4.6 to v3.9.1
- Updated Node.js test matrix from `[18, 20, 22]` to `[20, 22, 24]`

## Test plan
- [ ] CI tests pass with updated Node.js versions
- [ ] GitHub Actions run successfully

🤖 Generated with [Claude Code](https://claude.ai/code)